### PR TITLE
Support #role-assignment and improve code modularity

### DIFF
--- a/src/umassstembot/bot.py
+++ b/src/umassstembot/bot.py
@@ -19,7 +19,7 @@ import custom_meme
 import coronavirus as corona
 import os
 import time
-from bot_helper import del_convo
+from bot_helper import del_convo, get_mhom
 
 intents = discord.Intents.default()
 intents.members = True
@@ -130,14 +130,18 @@ async def on_message_delete(message):
         - message: context of the deleted message (used to get the message contents)
     """
     author = message.author
-    channel = client.get_channel(557002016782680076)
     try:
-        if message.guild.id == 387465995176116224 and author.id != 98138045173227520: # UMass STEM Discord server ID and not caleb
-            if (BOT_ROLE not in [role.name.lower() for role in author.roles]) and author.id != '98138045173227520':
-                content = message.content
-                await channel.send('_Deleted Message_\n**Message sent by:** ' + author.mention + '\n**Channel:** ' + message.channel.mention + '\n**Contents:** *' + content + '*\n--------------')
+        is_bot = BOT_ROLE in [role.name.lower() for role in author.roles]
+        if message.guild.id == 387465995176116224 and author.id != 98138045173227520 and not is_bot: # UMass STEM Discord server ID and not caleb
+            content = message.content
+            if message.channel.id == ROLE_ASSIGNMENT_CHANNEL_ID:
+                channel = client.get_channel(833907648846888982) # role-messages
+                await channel.send('_Role Message_\n**User:** ' + author.mention + '\n**Contents:** *' + content + '*\n**Setup Complete:** ' + str(await get_mhom(author.roles) is None) + '\n--------------')
+            else:     
+                channel = client.get_channel(557002016782680076) # deleted-messages
+                await channel.send('_Deleted Message_\n**Message sent by:** ' + author.mention + '\n**Channel:** ' + message.channel.mention + '\n**Contents:** *' + content + '*\n--------------') 
     except:
-        pass
+        print('Deleted message from {} failed to send to the channel'.format(author.mention))
 
 @client.event
 async def on_message_edit(before, after):
@@ -151,7 +155,7 @@ async def on_message_edit(before, after):
     channel = client.get_channel(557002016782680076)
     try:
         if before.guild.id == 387465995176116224 and author.id != 98138045173227520: # UMass STEM Discord server ID and not caleb
-            if (BOT_ROLE not in [role.name.lower() for role in author.roles]) and author.id != '98138045173227520':
+            if (BOT_ROLE not in [role.name.lower() for role in author.roles]):
                 before_content = before.content
                 after_content = after.content
                 await channel.send(
@@ -162,7 +166,7 @@ async def on_message_edit(before, after):
                     '**Post-edit contents:** *'+ after_content + '*\n' \
                     '--------------')
     except:
-        pass
+        print('Edited message from {} failed to send to the channel'.format(author.mention))
 
 # vvv GENERAL COMMANDS vvv
 

--- a/src/umassstembot/bot_helper.py
+++ b/src/umassstembot/bot_helper.py
@@ -1,6 +1,6 @@
 import discord
 import asyncio
-
+from discord.utils import get
 
 async def del_convo(user_msg, bot_msg, delay):
     """
@@ -13,3 +13,30 @@ async def del_convo(user_msg, bot_msg, delay):
     """
     await bot_msg.delete(delay=delay)
     await user_msg.delete(delay=delay)
+
+async def get_mhom(roles):
+    """
+    Returns the 'Missing Housing or Major Role' if the role list has the role
+
+    Parameters:
+    - member: roles list to check
+    
+    Returns:
+    - role: 'Missing Housing or Major' role object, if the list doesn't have it then None is returned
+    """
+    return get(roles, id=444868818997608460) # Missing Housing or Major role id
+
+async def contains_role(roles, name):
+    """
+    Checks if the role list contains a role with the name 'name'
+
+    Parameters:
+    - roles: list of role objects
+    - name: name of role
+    
+    Returns:
+    - role: role object that has the name 'name'
+    """
+    for r in roles:
+        if r.name.lower() == name:
+            return r

--- a/src/umassstembot/stem_role_commands.py
+++ b/src/umassstembot/stem_role_commands.py
@@ -2,7 +2,7 @@ import discord
 import asyncio
 from stem_server_roles import HOUSING_ROLE_IDS, MAJOR_ROLE_IDS, CLASS_ROLE_IDS, GRAD_YEAR_ROLE_IDS, SPECIAL_ROLE_IDS, PRONOUN_ROLE_IDS
 from discord.utils import get
-from bot_helper import del_convo
+from bot_helper import del_convo, get_mhom, contains_role
 
 def merge_dict(dicts): # merges dictionaries together
     z = dicts[0].copy()
@@ -219,7 +219,6 @@ async def stem_add_role(ctx, member, client):
         color=discord.Color.red()))
     await del_convo(ctx.message, message, 15)
 
-
 async def check_major_housing_role(member, client, role, is_add):
     member_has_hr = False
     member_has_m = False
@@ -234,9 +233,7 @@ async def check_major_housing_role(member, client, role, is_add):
             member_has_hr = True
         if role.id in MAJOR_ROLE_IDS:
             member_has_m = True
-    for role in member.guild.roles:
-        if role.name.lower() == 'missing housing or major role':
-            mhom = role
+    mhom = await get_mhom(member.guild.roles)
     if mhom in member.roles: # check if the member has the missing housing or major role
         if member_has_hr and member_has_m:
             await member.remove_roles(mhom) #removes missing housing or major role


### PR DESCRIPTION
Automatically deleted messages in the #role-assignment channel now are styled and sent to the #role-messages channel.  A check was also added to show whether a user has set up their roles completely when their deleted message is output to the channel.

Closes #79 